### PR TITLE
Update options.cpp

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2201,7 +2201,7 @@ void options_manager::add_options_graphics()
         { "color_pixel_sepia_dark", to_translation( "Sepia Dark" ) },
         { "color_pixel_blue_dark", to_translation( "Blue Dark" ) },
         { "color_pixel_custom", to_translation( "Custom" ) },
-    }, "color_pixel_sepia_light", COPT_CURSES_HIDE
+    }, "color_pixel_blue_dark", COPT_CURSES_HIDE
        );
 
     add( "MEMORY_RGB_DARK_RED", "graphics", to_translation( "Custom dark color RGB overlay - RED" ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Change memory map overlay preset option default to Blue Dark"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I recall being very disorientated as a new player when the memory tiles are rendered brighter than your immediate visible surroundings while in the dark. A new player is very likely to find themselves in the dark when starting a game. Screenshots attached for emphasis. I think this would be a nice change for people coming into a new stable version and ease the barrier of entry.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Changed the default memory map overlay preset setting to Blue Dark instead of Sepia Light, which I find much more intuitive, and is also suggested per https://www.reddit.com/r/cataclysmdda/comments/ppwq9f/cataclysm_dda_on_android_an_indepth_tweaking_guide/
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leave as is
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
